### PR TITLE
pipes-rs: update cargo hash, add flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1617631617,
+        "narHash": "sha256-PARRCz55qN3gy07VJZIlFeOX420d0nGF0RzGI/9hVlw=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b2c27d1a81b0dc266270fa8aeecebbd1807fc610",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1618186662,
+        "narHash": "sha256-tBgOlf6M+BjaJyYXHIt+LNjQRUqJpf5pXy3/0KKUS7E=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "82bcb97e1bc6b90ece62687e33a1b44f6830daa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      rec {
+        packages = {
+          pipes-rs = pkgs.callPackage ./pkgs/pipes-rs.nix { };
+        };
+      }
+    );
+}

--- a/pkgs/pipes-rs.nix
+++ b/pkgs/pipes-rs.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-IqFvU0berXgt8mgi5NPuO7Vv/p+p1EP+7jY33XDZBLk=";
   };
   
-  cargoSha256 = "sha256-zw2bxtjAQCsUOyAPwwfxb5W8JII+aqC6faQD4d66xm8=";
+  cargoSha256 = "sha256-B//im6wRphm6rVVrD/lyotGjZ26xXz4KeYAsEqVEywM=";
 
   doCheck = false;
 


### PR DESCRIPTION
I added a flake.nix, so now you can do `nix run .#pipes-rs` in this repo or `nix run github:nikhiljha/nix-pkgs#pipes-rs` anywhere.

I also updated the `cargoSha256` hash for `pipes-rs`, which probably wasn't updated after bumping src. No worries :-)

---

Side note, on my personal machine I ran `nix registry add nikhil github:nikhiljha/nix-pkgs`. So I can now use `nikhil` as shorthand for `github:nikhiljha/nix-pkgs` on my laptop.